### PR TITLE
[compiler] Add None type handling with sentinel value

### DIFF
--- a/torch_tvm/compiler.cpp
+++ b/torch_tvm/compiler.cpp
@@ -45,10 +45,11 @@ tvm::relay::Expr TVMCompiler::convertToRelay(const IValue& val) {
     return v;
   }
   // TODO Add None type to Relay
+  // HACK sentinel value used for None type
   if (val.isNone()) {
     auto x = tvm::runtime::NDArray::Empty(
-        {}, tvm::runtime::String2TVMType("int32"), ctx_);
-    reinterpret_cast<int32_t*>(x->data)[0] = 0;
+        {}, tvm::runtime::String2TVMType("uint64"), ctx_);
+    reinterpret_cast<uint64_t*>(x->data)[0] = getNoneSentinel();
     auto v = tvm::relay::ConstantNode::make(x);
     return v;
   }

--- a/torch_tvm/operators.h
+++ b/torch_tvm/operators.h
@@ -10,6 +10,9 @@ tvm::relay::Expr getOperator(
     torch::jit::Node* node,
     tvm::Array<tvm::relay::Expr> inputs);
 
+bool relayIsNone(tvm::relay::Expr e);
+uint64_t getNoneSentinel();
+
 using TVMOpFunctor = std::function<tvm::relay::Expr(
     torch::jit::Node* node,
     tvm::Array<tvm::relay::Expr> inputs)>;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #24 [WIP] Use PackedFunc to enable custom TVM operator registration from python
* #23 [benchmark] Add initial benchmark file
* #22 [compiler] Improve conversion from PyTorch IR to Relay
* #21 [testing] Improve testing to include models, image inputs and autotuned parameters
* **#17 [compiler] Add None type handling with sentinel value**
* #14 [compiler] Support operators with multiple outputs

