### PR TITLE
[compiler] Expose relay ops registered as torch.ops.tvm.__

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -4,6 +4,16 @@ import torch_tvm
 
 class TestCore(TVMTest):
     @TVMTest.given(shape=TVMTest.rand_shape(rank=1))
+    def test_registry(self, shape):
+        x = torch.rand(8)
+
+        y0 = torch.ops.tvm.relu(x)
+        print(x, y0)
+        y1 = torch.relu(x)
+
+        torch.testing.assert_allclose(y0, y1)
+
+    @TVMTest.given(shape=TVMTest.rand_shape(rank=1))
     def test_core(self, shape):
         x = torch.rand(shape)
         y = torch.rand(shape)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5,10 +5,8 @@ import torch_tvm
 class TestCore(TVMTest):
     @TVMTest.given(shape=TVMTest.rand_shape(rank=1))
     def test_registry(self, shape):
-        x = torch.rand(8)
-
+        x = torch.rand(shape)
         y0 = torch.ops.tvm.relu(x)
-        print(x, y0)
         y1 = torch.relu(x)
 
         torch.testing.assert_allclose(y0, y1)

--- a/torch_tvm/compiler.cpp
+++ b/torch_tvm/compiler.cpp
@@ -270,12 +270,8 @@ void TVMCompiler::run(Stack& stack) {
     tvm::runtime::NDArray ret_val = cache_[spec].get_output(i);
     auto dl_tensor = ret_val.ToDLPack();
     auto tensor = at::fromDLPack(dl_tensor);
-    auto new_tensor = at::empty_like(tensor);
-    auto new_dl_tensor = at::toDLPack(new_tensor);
-    ret_val = cache_[spec].get_output(i, &new_dl_tensor->dl_tensor);
-    auto var = torch::autograd::make_variable(at::fromDLPack(new_dl_tensor));
+    auto var = torch::autograd::make_variable(tensor);
     stack.push_back(IValue(var));
-
     i++;
   }
 }

--- a/torch_tvm/compiler.cpp
+++ b/torch_tvm/compiler.cpp
@@ -190,6 +190,9 @@ TVMCompiler::TVMCompiler(
   }
   ctx_.device_id = 0;
   subgraph_ = node->g(attr::Subgraph);
+  auto pfb = tvm::runtime::Registry::Get("relay.build_module._BuildModule");
+  AT_ASSERT(pfb);
+  build_mod_ = (*pfb)();
 }
 
 void TVMCompiler::run(Stack& stack) {
@@ -204,7 +207,6 @@ void TVMCompiler::run(Stack& stack) {
 
   CompleteArgumentSpec spec{false, ArrayRef<IValue>(inputs)};
 
-  std::vector<Value*> input_values_;
   if (cache_.find(spec) == cache_.end()) {
     for (auto& kv : value_to_ivalue) {
       kv.first->inferTypeFrom(kv.second.toTensor());
@@ -214,7 +216,7 @@ void TVMCompiler::run(Stack& stack) {
     // or fall back to the JIT interpreter for execution
     tvm::relay::Function tvm_func;
     try {
-      tvm_func = convertToRelay(subgraph_, &input_values_);
+      tvm_func = convertToRelay(subgraph_, &cache_[spec].input_values);
     } catch(const std::exception& e) {
       if (strict_) {
         AT_ERROR("Pytorch TVM: fail to convert to relay, exception: ", e.what());
@@ -223,13 +225,10 @@ void TVMCompiler::run(Stack& stack) {
       InterpreterState(Code(subgraph_)).run(stack);
       return;
     }
-    auto pfb = tvm::runtime::Registry::Get("relay.build_module._BuildModule");
-    AT_ASSERT(pfb);
-    tvm::runtime::Module build_mod = (*pfb)();
-    auto build_f = build_mod.GetFunction("build", false);
-    auto json_f = build_mod.GetFunction("get_graph_json", false);
-    auto mod_f = build_mod.GetFunction("get_module", false);
-    auto set_opt_level_f = build_mod.GetFunction("set_opt_level", false);
+    auto build_f = build_mod_.GetFunction("build", false);
+    auto json_f = build_mod_.GetFunction("get_graph_json", false);
+    auto mod_f = build_mod_.GetFunction("get_module", false);
+    auto set_opt_level_f = build_mod_.GetFunction("set_opt_level", false);
     set_opt_level_f(opt_level_);
     tvm::Array<HalideIR::Expr> target_pair;
     target_pair.push_back(tvm::ir::StringImm::make(device_type_));
@@ -249,14 +248,14 @@ void TVMCompiler::run(Stack& stack) {
     AT_CHECK(subgraph_->outputs().size() == n, "Compiled subgraph with mismatching num outputs");
   }
 
-  for (auto i = 0; i < input_values_.size(); ++i) {
-    auto* value = input_values_[i];
+  for (auto i = 0; i < cache_[spec].input_values.size(); ++i) {
+    auto *value = cache_[spec].input_values[i];
     if (!value_to_ivalue.count(value)) {
       auto optional_ivalue = toIValue(value);
       AT_ASSERT(optional_ivalue.has_value());
       value_to_ivalue[value] = optional_ivalue.value();
     }
-    auto ivalue = value_to_ivalue.at(input_values_[i]);
+    auto ivalue = value_to_ivalue.at(cache_[spec].input_values[i]);
     auto tensor = ivalue.toTensor().to(at::kFloat);
     auto dl_tensor = at::toDLPack(tensor);
     cache_[spec].set_input(i, tvm::runtime::NDArray::FromDLPack(dl_tensor));

--- a/torch_tvm/compiler.cpp
+++ b/torch_tvm/compiler.cpp
@@ -267,10 +267,15 @@ void TVMCompiler::run(Stack& stack) {
   drop(stack, num_inputs);
   int i = 0;
   for (const auto& output : subgraph_->outputs()) {
-    tvm::runtime::NDArray ret_val = cache_[spec].get_output(i++);
+    tvm::runtime::NDArray ret_val = cache_[spec].get_output(i);
     auto dl_tensor = ret_val.ToDLPack();
     auto tensor = at::fromDLPack(dl_tensor);
-    auto var = torch::autograd::make_variable(tensor);
+    auto new_tensor = at::empty_like(tensor);
+    auto new_dl_tensor = at::toDLPack(new_tensor);
+    ret_val = cache_[spec].get_output(i, &new_dl_tensor->dl_tensor);
+    auto var = torch::autograd::make_variable(at::fromDLPack(new_dl_tensor));
     stack.push_back(IValue(var));
+
+    i++;
   }
 }

--- a/torch_tvm/compiler.h
+++ b/torch_tvm/compiler.h
@@ -12,6 +12,8 @@ struct TVMObject {
   tvm::PackedFunc kernel;
   tvm::PackedFunc set_input;
   tvm::PackedFunc get_output;
+  // Map input indices to values in the subgraph
+  std::vector<torch::jit::Value *> input_values;
 };
 
 struct TVMCompiler {
@@ -33,6 +35,7 @@ struct TVMCompiler {
   std::string device_type_;
   std::string device_;
   std::string host_;
+  tvm::runtime::Module build_mod_;
 
   tvm::relay::Var convertToRelay(torch::jit::Value* val);
   tvm::relay::Expr convertToRelay(const torch::jit::IValue& val);

--- a/torch_tvm/operators.cpp
+++ b/torch_tvm/operators.cpp
@@ -45,18 +45,12 @@ RegisterTVMOperator::RegisterTVMOperator(std::vector<TVMOpMap> ops) {
         wrapper_graph.appendNode(node);
         wrapper_graph.registerOutput(node->output());
 
-        std::cerr << op.name << " created as " << wrapper_graph << "\n";
-
         Symbol tvm_sym = Symbol::fromQualString("tvm::CompilationGroup");
         node = SubgraphUtils::createSingletonSubgraph(node, tvm_sym);
-        std::cerr << op.name << " then " << wrapper_graph << "\n";
         auto cc = std::make_shared<TVMCompiler>(node);
-        //, opt_level, strict,
-        // device_type, device, host);
 
         // NB: We assume all relay ops are pure
         auto options = OperatorOptions().aliasAnalysis(AliasAnalysisKind::PURE);
-        std::cerr << "registering tvm::" << op.name << "\n";
         // We don't know the true number of inputs so we make it varargs
         auto torch_operator =
             Operator(FunctionSchema("tvm::" + op.name, "", schema.arguments(),
@@ -68,8 +62,7 @@ RegisterTVMOperator::RegisterTVMOperator(std::vector<TVMOpMap> ops) {
                      },
                      options);
         RegisterOperators torch_register_ops({torch_operator});
-
-      } // for
+      }
     }
   }
 }

--- a/torch_tvm/operators.cpp
+++ b/torch_tvm/operators.cpp
@@ -40,7 +40,7 @@ RegisterTVMOperator::RegisterTVMOperator(std::vector<TVMOpMap> ops) {
         for (const auto &inp : schema.arguments()) {
           torch_inputs.emplace_back(wrapper_graph.addInput());
         }
-        Node *node =
+        Node* node =
             wrapper_graph.create(op.sym, torch_inputs, schema.returns().size());
         wrapper_graph.appendNode(node);
         wrapper_graph.registerOutput(node->output());
@@ -139,7 +139,7 @@ RegisterTVMOperatorSchedule::RegisterTVMOperatorSchedule(
 
 RegisterTVMOperator reg({
     {Symbol::fromQualString("aten::add"),
-     [](Node *node, tvm::Array<tvm::relay::Expr> inputs) {
+     [](Node* node, tvm::Array<tvm::relay::Expr> inputs) {
        auto op = tvm::relay::Op::Get("add");
        AT_ASSERT(inputs.size() == 3);
        tvm::Array<tvm::relay::Expr> add_inputs = {inputs[0], inputs[1]};
@@ -152,7 +152,7 @@ RegisterTVMOperator reg({
        return out;
      }},
     {Symbol::fromQualString("aten::add_"),
-     [](Node *node, tvm::Array<tvm::relay::Expr> inputs) {
+     [](Node* node, tvm::Array<tvm::relay::Expr> inputs) {
        auto op = tvm::relay::Op::Get("add");
        AT_ASSERT(inputs.size() == 3);
        tvm::Array<tvm::relay::Expr> add_inputs = {inputs[0], inputs[1]};
@@ -165,7 +165,7 @@ RegisterTVMOperator reg({
        return out;
      }},
     {Symbol::fromQualString("aten::_convolution"),
-     [](Node *node, tvm::Array<tvm::relay::Expr> inputs) {
+     [](Node* node, tvm::Array<tvm::relay::Expr> inputs) {
        bool is_transpose = relayToConstant<bool>(inputs[6]);
        // check the operator to emit base on is_transpose
        auto op = tvm::relay::Op::Get("nn.conv2d");
@@ -219,7 +219,7 @@ RegisterTVMOperator reg({
        return out;
      }},
     {Symbol::fromQualString("aten::batch_norm"),
-     [](Node *node, tvm::Array<tvm::relay::Expr> inputs) -> tvm::relay::Expr {
+     [](Node* node, tvm::Array<tvm::relay::Expr> inputs) -> tvm::relay::Expr {
        auto op = tvm::relay::Op::Get("nn.batch_norm");
        AT_CHECK(inputs.size() == 9, "batch_norm received ", inputs.size(), " inputs");
        AT_CHECK(relayToConstant<bool>(inputs[5]) == false, "batch_norm is in training mode");
@@ -275,20 +275,20 @@ RegisterTVMOperator reg({
        return tvm::relay::TupleGetItem(n);
      }},
     {Symbol::fromQualString("aten::relu_"),
-     [](Node *node, tvm::Array<tvm::relay::Expr> inputs) {
+     [](Node* node, tvm::Array<tvm::relay::Expr> inputs) {
        auto op = tvm::relay::Op::Get("nn.relu");
        auto out = tvm::relay::CallNode::make(op, inputs, tvm::Attrs(), {});
        return out;
      }},
     {Symbol::fromQualString("aten::relu"),
-     [](Node *node, tvm::Array<tvm::relay::Expr> inputs) {
+     [](Node* node, tvm::Array<tvm::relay::Expr> inputs) {
        auto op = tvm::relay::Op::Get("nn.relu");
        auto out = tvm::relay::CallNode::make(op, inputs, tvm::Attrs(), {});
        return out;
      },
      "relu"},
     {Symbol::fromQualString("aten::threshold_"),
-     [](Node *node, tvm::Array<tvm::relay::Expr> inputs) {
+     [](Node* node, tvm::Array<tvm::relay::Expr> inputs) {
        AT_CHECK(!relayIsNone(inputs[0]));
        AT_CHECK(!relayIsNone(inputs[1]));
        AT_CHECK(!relayIsNone(inputs[2]));
@@ -303,13 +303,13 @@ RegisterTVMOperator reg({
        return out;
      }},
     {Symbol::fromQualString("aten::mul"),
-     [](Node *node, tvm::Array<tvm::relay::Expr> inputs) {
+     [](Node* node, tvm::Array<tvm::relay::Expr> inputs) {
        auto op = tvm::relay::Op::Get("multiply");
        auto out = tvm::relay::CallNode::make(op, inputs, tvm::Attrs(), {});
        return out;
      }},
     {Symbol::fromQualString("aten::avg_pool2d"),
-     [](Node *node, tvm::Array<tvm::relay::Expr> inputs) {
+     [](Node* node, tvm::Array<tvm::relay::Expr> inputs) {
        auto op = tvm::relay::Op::Get("nn.avg_pool2d");
        auto pool_attrs = tvm::make_node<tvm::relay::AvgPool2DAttrs>();
        pool_attrs->pool_size = relayToArray<tvm::relay::IndexExpr>(inputs[1]);
@@ -329,7 +329,7 @@ RegisterTVMOperator reg({
        return out;
      }},
     {Symbol::fromQualString("aten::adaptive_avg_pool2d"),
-     [](Node *node, tvm::Array<tvm::relay::Expr> inputs) {
+     [](Node* node, tvm::Array<tvm::relay::Expr> inputs) {
        static const tvm::relay::Op& op = tvm::relay::Op::Get("contrib.adaptive_avg_pool2d");
        auto pool_attrs = tvm::make_node<tvm::relay::AdaptivePool2DAttrs>();
        pool_attrs->output_size = relayToArray<tvm::relay::IndexExpr>(inputs[1]);
@@ -338,7 +338,7 @@ RegisterTVMOperator reg({
        return out;
      }},
     {Symbol::fromQualString("aten::max_pool2d"),
-     [](Node *node, tvm::Array<tvm::relay::Expr> inputs) {
+     [](Node* node, tvm::Array<tvm::relay::Expr> inputs) {
        auto pool_attrs = tvm::make_node<tvm::relay::MaxPool2DAttrs>();
        pool_attrs->pool_size = relayToArray<tvm::relay::IndexExpr>(inputs[1]);
        auto strides = relayToArray<tvm::relay::IndexExpr>(inputs[2]);
@@ -358,7 +358,7 @@ RegisterTVMOperator reg({
        return out;
      }},
     {Symbol::fromQualString("aten::reshape"),
-     [](Node *node, tvm::Array<tvm::relay::Expr> inputs) {
+     [](Node* node, tvm::Array<tvm::relay::Expr> inputs) {
        auto op = tvm::relay::Op::Get("reshape");
        auto attrs = tvm::make_node<tvm::relay::ReshapeAttrs>();
        attrs->newshape = relayToArray<tvm::Integer>(inputs[1]);
@@ -370,7 +370,7 @@ RegisterTVMOperator reg({
        return out;
      }},
     {Symbol::fromQualString("aten::linear"),
-     [](Node *node, tvm::Array<tvm::relay::Expr> inputs) {
+     [](Node* node, tvm::Array<tvm::relay::Expr> inputs) {
        auto dense_attrs = tvm::make_node<tvm::relay::DenseAttrs>();
        auto out = tvm::relay::CallNode::make(tvm::relay::Op::Get("nn.dense"), {inputs[0], inputs[1]}, tvm::Attrs(dense_attrs), {});
 

--- a/torch_tvm/operators.cpp
+++ b/torch_tvm/operators.cpp
@@ -51,7 +51,6 @@ RegisterTVMOperator::RegisterTVMOperator(std::vector<TVMOpMap> ops) {
 
         // NB: We assume all relay ops are pure
         auto options = OperatorOptions().aliasAnalysis(AliasAnalysisKind::PURE);
-        // We don't know the true number of inputs so we make it varargs
         auto torch_operator =
             Operator(FunctionSchema("tvm::" + op.name, "", schema.arguments(),
                                     schema.returns(), false, false),

--- a/torch_tvm/operators.h
+++ b/torch_tvm/operators.h
@@ -17,9 +17,17 @@ using TVMOpFunctor = std::function<tvm::relay::Expr(
     tvm::Array<tvm::relay::Expr> inputs)>;
 using TVMScheduleFunctor = std::function<const tvm::runtime::PackedFunc*()>;
 
+struct TVMOpMap {
+  TVMOpMap(torch::jit::Symbol sym_, TVMOpFunctor fn_, std::string name_ = "")
+      : sym(sym_), fn(fn_), name(name_) {}
+
+  torch::jit::Symbol sym;
+  TVMOpFunctor fn;
+  std::string name;
+};
+
 struct RegisterTVMOperator {
-  RegisterTVMOperator(
-      std::vector<std::pair<torch::jit::Symbol, TVMOpFunctor>> ops);
+  RegisterTVMOperator(std::vector<TVMOpMap> ops);
 };
 
 struct RegisterTVMOperatorSchedule {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #44 [compiler] Expose `to_relay` API which hands the Relay graph over in Python
* **#43 [compiler] Expose relay ops registered as torch.ops.tvm.__**

