### PR TITLE
[compiler] Expose `to_relay` API which hands the Relay graph over in Python

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -19,14 +19,14 @@ class TestCore(TVMTest):
         inputs = [x,y,z]
 
         torch_tvm.enable()
+
         trace_tvm = torch.jit.trace(add, inputs)
-        torch_tvm.disable()
 
+        relay_graph = torch_tvm.to_relay(trace_tvm, inputs)
         relay_graph = torch_tvm.to_relay(add, inputs)
-        print(relay_graph)
-
         relay_graph = torch_tvm.to_relay(mul, inputs)
-        print(relay_graph)
+
+        torch_tvm.disable()
 
     @TVMTest.given(shape=TVMTest.rand_shape(rank=1))
     def test_registry(self, shape):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -3,6 +3,22 @@ import torch
 import torch_tvm
 
 class TestCore(TVMTest):
+    def test_get_handle(self):
+        shape = 8
+        x = torch.rand(shape)
+        y = torch.rand(shape)
+        z = torch.rand(shape)
+        def add(a, b, c):
+            return a + b + c
+
+        inputs = [x,y,z]
+
+        torch_tvm.enable()
+        trace_tvm = torch.jit.trace(add, inputs)
+        torch_tvm.disable()
+
+        torch_tvm.push_relay_expr(trace_tvm.graph_for(*inputs))
+
     @TVMTest.given(shape=TVMTest.rand_shape(rank=1))
     def test_core(self, shape):
         x = torch.rand(shape)

--- a/torch_tvm/__init__.py
+++ b/torch_tvm/__init__.py
@@ -7,11 +7,12 @@ import torch
 from tvm import relay # This registers all the schedules
 
 from ._torch_tvm import *
+from ._torch_tvm import _push_relay_expr
 from tvm._ffi.function import _init_api # This lets us use PackedFunc with torch_tvm
 _init_api("torch_tvm")
 
 def to_relay(pt_func, inputs):
     if type(pt_func) is not torch._C.Function:
         pt_func = torch.jit.trace(pt_func, inputs)
-    handle = push_relay_expr(pt_func.graph_for(*inputs), inputs)
-    return pop_relay_expr(handle)
+    handle = _push_relay_expr(pt_func.graph_for(*inputs), inputs)
+    return _pop_relay_expr(handle)

--- a/torch_tvm/compiler.cpp
+++ b/torch_tvm/compiler.cpp
@@ -8,7 +8,7 @@
 
 using namespace torch::jit;
 
-tvm::relay::Var TVMCompiler::convertToRelay(Value* val) {
+tvm::relay::Var TVMCompiler::convertToRelay(Value* val, TVMContext ctx) {
   auto optional_ivalue = toIValue(val);
   if (optional_ivalue.has_value()) {
     val->inferTypeFrom(optional_ivalue.value().toTensor());
@@ -27,11 +27,11 @@ tvm::relay::Var TVMCompiler::convertToRelay(Value* val) {
   AT_ASSERT(0);
 }
 
-tvm::relay::Expr TVMCompiler::convertToRelay(const IValue& val) {
+tvm::relay::Expr TVMCompiler::convertToRelay(const IValue& val, TVMContext ctx) {
   // All doubles are converted to floats
   if (val.isDouble()) {
     auto x = tvm::runtime::NDArray::Empty(
-        {}, tvm::runtime::String2TVMType("float32"), ctx_);
+        {}, tvm::runtime::String2TVMType("float32"), ctx);
     auto d = val.toDouble();
     AT_CHECK(d <= std::numeric_limits<float>::max());
     AT_CHECK(d >= std::numeric_limits<float>::lowest());
@@ -43,7 +43,7 @@ tvm::relay::Expr TVMCompiler::convertToRelay(const IValue& val) {
   // All Ints are converted to int32, which may overflow
   if (val.isInt()) {
     auto x = tvm::runtime::NDArray::Empty(
-        {}, tvm::runtime::String2TVMType("int32"), ctx_);
+        {}, tvm::runtime::String2TVMType("int32"), ctx);
     auto l = val.toInt();
     AT_CHECK(l <= std::numeric_limits<int32_t>::max());
     AT_CHECK(l >= std::numeric_limits<int32_t>::lowest());
@@ -53,7 +53,7 @@ tvm::relay::Expr TVMCompiler::convertToRelay(const IValue& val) {
   }
   if (val.isBool()) {
     auto x = tvm::runtime::NDArray::Empty(
-        {}, tvm::runtime::String2TVMType("bool"), ctx_);
+        {}, tvm::runtime::String2TVMType("bool"), ctx);
     reinterpret_cast<bool*>(x->data)[0] = val.toBool();
     auto v = tvm::relay::ConstantNode::make(x);
     return v;
@@ -62,7 +62,7 @@ tvm::relay::Expr TVMCompiler::convertToRelay(const IValue& val) {
   // HACK sentinel value used for None type
   if (val.isNone()) {
     auto x = tvm::runtime::NDArray::Empty(
-        {}, tvm::runtime::String2TVMType("uint64"), ctx_);
+        {}, tvm::runtime::String2TVMType("uint64"), ctx);
     reinterpret_cast<uint64_t*>(x->data)[0] = getNoneSentinel();
     auto v = tvm::relay::ConstantNode::make(x);
     return v;
@@ -71,7 +71,7 @@ tvm::relay::Expr TVMCompiler::convertToRelay(const IValue& val) {
     tvm::Array<tvm::relay::Expr> tuple_elems;
     for (const auto& elem : val.toIntList()->elements()) {
       auto x = tvm::runtime::NDArray::Empty(
-          {}, tvm::runtime::String2TVMType("int32"), ctx_);
+          {}, tvm::runtime::String2TVMType("int32"), ctx);
       AT_CHECK(elem <= std::numeric_limits<int32_t>::max());
       AT_CHECK(elem >= std::numeric_limits<int32_t>::lowest());
       reinterpret_cast<int32_t*>(x->data)[0] = elem;
@@ -85,15 +85,17 @@ tvm::relay::Expr TVMCompiler::convertToRelay(const IValue& val) {
 }
 
 tvm::relay::Function TVMCompiler::convertToRelay(
-    std::shared_ptr<Graph> subgraph, std::vector<Value*>* input_values) {
+    std::shared_ptr<Graph> subgraph, TVMContext ctx, std::vector<Value*>* input_values) {
   std::unordered_map<Value*, tvm::relay::Expr> value_map;
   tvm::Array<tvm::relay::Var> input_vars;
 
   for (const auto& input : subgraph->inputs()) {
     AT_ASSERT(input->isCompleteTensor());
-    auto v = convertToRelay(input);
+    auto v = convertToRelay(input, ctx);
     input_vars.push_back(v);
-    input_values->emplace_back(input);
+    if (input_values) {
+      input_values->emplace_back(input);
+    }
     value_map[input] = v;
   }
 
@@ -115,12 +117,14 @@ tvm::relay::Function TVMCompiler::convertToRelay(
               break;
             } else {
               if (optional_ivalue.value().isTensor()) {
-                input_values->emplace_back(input);
-                auto input_var = convertToRelay(input);
+                if (input_values) {
+                  input_values->emplace_back(input);
+                }
+                auto input_var = convertToRelay(input, ctx);
                 input_vars.push_back(input_var);
                 value_map[input] = input_var;
               } else {
-                value_map[input] = convertToRelay(optional_ivalue.value());
+                value_map[input] = convertToRelay(optional_ivalue.value(), ctx);
               }
             }
           }
@@ -214,7 +218,7 @@ void TVMCompiler::run(Stack& stack) {
     // or fall back to the JIT interpreter for execution
     tvm::relay::Function tvm_func;
     try {
-      tvm_func = convertToRelay(subgraph_, &input_values_);
+      tvm_func = convertToRelay(subgraph_, ctx_, &cache_[spec].input_values);
     } catch(const std::exception& e) {
       if (strict_) {
         AT_ERROR("Pytorch TVM: fail to convert to relay, exception: ", e.what());

--- a/torch_tvm/compiler.h
+++ b/torch_tvm/compiler.h
@@ -34,8 +34,11 @@ struct TVMCompiler {
   std::string device_;
   std::string host_;
 
-  tvm::relay::Var convertToRelay(torch::jit::Value* val);
-  tvm::relay::Expr convertToRelay(const torch::jit::IValue& val);
-  tvm::relay::Function convertToRelay(
-      std::shared_ptr<torch::jit::Graph> subgraph, std::vector<torch::jit::Value*>* input_values);
+ public:
+  static tvm::relay::Var convertToRelay(torch::jit::Value* val, TVMContext ctx);
+  static tvm::relay::Expr convertToRelay(const torch::jit::IValue& val, TVMContext ctx);
+  static tvm::relay::Function convertToRelay(
+      std::shared_ptr<torch::jit::Graph> subgraph, TVMContext ctx,
+      std::vector<torch::jit::Value*>* input_values = nullptr
+      );
 };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#44 [compiler] Expose `to_relay` API which hands the Relay graph over in Python**
* #43 [compiler] Expose relay ops registered as torch.ops.tvm.__

