### PR TITLE
[build] Better detect initial build by checking for presence of CMakeCache.txt, fixes #53

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -166,8 +166,8 @@ class cmake_build(setuptools.Command):
           
 
     def run(self):
-        is_initial_build = not os.path.exists(CMAKE_BUILD_DIR)
-        if is_initial_build:
+        is_initial_build = not os.path.exists(CMAKE_BUILD_DIR) or not os.path.exists(os.path.join(CMAKE_BUILD_DIR, "CMakeCache.txt"))
+        if is_initial_build and not os.path.exists(CMAKE_BUILD_DIR):
             os.makedirs(CMAKE_BUILD_DIR)
         if is_initial_build or RERUN_CMAKE:
             self._run_cmake()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* **#56 [build] Better detect initial build by checking for presence of CMakeCache.txt, fixes #53**

