### PR TITLE
[fusion] Migrate away from CustomFuseGraph

### DIFF
--- a/torch_tvm/compiler.cpp
+++ b/torch_tvm/compiler.cpp
@@ -11,7 +11,16 @@ using namespace torch::jit;
 tvm::relay::Var TVMCompiler::convertToRelay(Value* val, TVMContext ctx) {
   auto optional_ivalue = toIValue(val);
   if (optional_ivalue.has_value()) {
-    val->inferTypeFrom(optional_ivalue.value().toTensor());
+    if (optional_ivalue.value().isTensor()) {
+      val->inferTypeFrom(optional_ivalue.value().toTensor());
+    } else {
+      auto expr = convertToRelay(optional_ivalue.value(), ctx)
+                      .as<tvm::relay::ConstantNode>();
+      return tvm::relay::VarNode::make(
+          val->debugName() +
+              std::to_string(reinterpret_cast<std::uintptr_t>(val)),
+          expr->tensor_type());
+    }
   }
   if (val->isCompleteTensor()) {
     auto pt_t = val->type()->cast<CompleteTensorType>();
@@ -226,7 +235,13 @@ void TVMCompiler::run(Stack& stack) {
 
   if (cache_.find(spec) == cache_.end()) {
     for (auto& kv : value_to_ivalue) {
-      kv.first->inferTypeFrom(kv.second.toTensor());
+      if (kv.second.isTensor()) {
+        kv.first->inferTypeFrom(kv.second.toTensor());
+      } else if (kv.second.isInt()) {
+        kv.first->setType(IntType::get());
+      } else {
+        AT_ASSERT(0, "Cannot handle this type yet");
+      }
     }
     // bail out mechanism: try to convert to Relay, if it fails to convert the
     // graph by any reason(i.e. op difference), depend on the user preference,

--- a/torch_tvm/fusion_pass.cpp
+++ b/torch_tvm/fusion_pass.cpp
@@ -1,0 +1,84 @@
+#include "fusion_pass.h"
+#include "operators.h"
+
+using namespace torch::jit;
+extern const torch::jit::Symbol tvm_sym =
+    torch::jit::Symbol::fromQualString("tvm::CompilationGroup");
+
+value_list sortReverseTopological(ArrayRef<Value*> inputs, Block* block) {
+  value_list result;
+  for (auto i : inputs) {
+    if (i->node()->owningBlock() == block) {
+      result.push_back(i);
+    }
+  }
+  // Sort in reverse topological order
+  std::sort(result.begin(), result.end(), [&](Value* a, Value* b) {
+    return a->node()->isAfter(b->node());
+  });
+  return result;
+}
+
+bool canHandle(Block* block, AliasDb& aliasDb);
+bool canHandle(Node* node, AliasDb& aliasDb) {
+  if (aliasDb.hasWriters(node)) {
+    return false;
+  }
+  if (node->kind() == prim::Loop) {
+    Block* body = node->blocks().at(0);
+    return canHandle(body, aliasDb);
+  }
+  return isSupported(node);
+}
+
+bool canHandle(Block* block, AliasDb& aliasDb) {
+  for (Node* node : block->nodes()) {
+    if (!canHandle(node, aliasDb)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+c10::optional<Node*> tryMerge(
+    Node* consumer,
+    Node* producer,
+    AliasDb& aliasDb) {
+  bool canMerge = canHandle(consumer, aliasDb) &&
+      aliasDb.moveBeforeTopologicallyValid(producer, consumer);
+
+  if (!canMerge) {
+    return c10::nullopt;
+  }
+
+  if (!consumer->hasAttribute(attr::Subgraph) && consumer->kind() != tvm_sym) {
+    consumer = SubgraphUtils::createSingletonSubgraph(consumer, tvm_sym);
+  }
+  SubgraphUtils::mergeNodeIntoSubgraph(producer, consumer);
+
+  return consumer;
+}
+
+graph_node_list::iterator scanNode(
+    Node* consumer,
+    AliasDb& aliasDb,
+    Block* block) {
+  auto inputs = sortReverseTopological(consumer->inputs(), block);
+  for (auto input : inputs) {
+    if (auto group = tryMerge(consumer, input->node(), aliasDb)) {
+      // we successfully merged, so the new group's `inputs` may have
+      // changed. So rescan the new group for more merging opportunities.
+      return group.value()->reverseIterator();
+    }
+  }
+  return ++consumer->reverseIterator();
+}
+
+void FuseSupportedOps(std::shared_ptr<Graph> graph) {
+  AliasDb aliasDb(graph);
+  auto block = graph->block();
+
+  for (auto it = block->nodes().rbegin(); it != block->nodes().rend();) {
+    it = scanNode(*it, aliasDb, block);
+  }
+}

--- a/torch_tvm/fusion_pass.h
+++ b/torch_tvm/fusion_pass.h
@@ -1,0 +1,7 @@
+#include <torch/csrc/jit/passes/alias_analysis.h>
+#include <torch/csrc/jit/passes/graph_fuser.h>
+#include <torch/csrc/jit/passes/utils/subgraph_utils.h>
+
+void FuseSupportedOps(std::shared_ptr<torch::jit::Graph> graph);
+
+extern const torch::jit::Symbol tvm_sym;

--- a/torch_tvm/operators.cpp
+++ b/torch_tvm/operators.cpp
@@ -413,11 +413,7 @@ RegisterTVMOperator reg({
 
 bool isSupported(Node* node) {
   auto map = getTVMOperatorMap();
-  auto can_handle = map.find(node->kind()) != map.end();
-  if (node->kind() == prim::Constant) {
-    can_handle = true;
-  }
-  return can_handle;
+  return map.find(node->kind()) != map.end();
 }
 
 tvm::relay::Expr getOperator(Node* node, tvm::Array<tvm::relay::Expr> inputs) {

--- a/torch_tvm/register.cpp
+++ b/torch_tvm/register.cpp
@@ -3,12 +3,11 @@
 #include <torch/csrc/jit/custom_operator.h>
 #include <torch/csrc/jit/operator_options.h>
 #include <torch/csrc/jit/pass_manager.h>
-#include <torch/csrc/jit/passes/graph_fuser.h>
 #include <torch/csrc/jit/pybind_utils.h>
 
 #include "compiler.h"
-#include "operators.h"
 #include "fuse_linear.h"
+#include "fusion_pass.h"
 
 namespace py = pybind11;
 using namespace torch::jit;
@@ -23,7 +22,6 @@ static int opt_level = 2;
 static std::string device_type = "cpu";
 static std::string device = "llvm -mcpu=core-avx2";
 static std::string host = "llvm -mcpu=core-avx2";
-static auto tvm_sym = Symbol::fromQualString("tvm::CompilationGroup");
 
 static std::unordered_map<size_t, tvm::relay::Expr> relay_exprs;
 static size_t relay_exprs_uuid = 0;
@@ -50,7 +48,7 @@ PYBIND11_MODULE(_torch_tvm, m) {
   RegisterPass pass([](std::shared_ptr<Graph>& g) {
     if (fusion_enabled) {
       FuseLinear(g);
-      CustomFuseGraph(g, isSupported, tvm_sym);
+      FuseSupportedOps(g);
     }
   });
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack):
* #67 [WIP] Loop impl
* **#66 [fusion] Migrate away from CustomFuseGraph**
* #65 Update on "[operators][fix] Prevent segfault if the passed in tensor hasn't been dimensioned yet"
* #64 [operators][fix] Prevent segfault if the passed in tensor hasn't been dimensioned yet

