### PR TITLE
Removed duplicate node creation.

### DIFF
--- a/torch_tvm/compiler.cpp
+++ b/torch_tvm/compiler.cpp
@@ -148,26 +148,11 @@ tvm::relay::Function TVMCompiler::convertToRelay(
       auto uses = value->uses();
       for (const auto& use : uses) {
         tvm::Array<tvm::relay::Expr> relay_inputs;
-        if (use.user->outputs().size() == 1) {
-          if (value_map.count(use.user->output())) {
-            continue;
-          }
-        } else {
-          bool node_already_inserted{false};
-          for (const auto& output : use.user->outputs()) {
-            if (value_map.count(output)) {
-              node_already_inserted = true;
-            } else {
-              // If one output node is created then all must have
-              // been created.
-              AT_CHECK(!node_already_inserted);
-            }
-          }
-          if (node_already_inserted) {
-            continue;
-          }
-        }
         auto skip_user = false;
+        if (std::any_of(use.user->outputs().begin(), use.user->outputs().end(),
+              [&value_map](Value* const output){return value_map.count(output);})) {
+          continue;
+        }
         for (const auto& input : use.user->inputs()) {
           if (value_map.find(input) == value_map.end()) {
             // We may be dealing with a constant, handle that here


### PR DESCRIPTION
Summary:
In current implementation if the node has multiple inputs then for each input we query its uses and for each use we try to create a node even though the node might have been created by uses of another input. This PR fixes that.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: