### PR TITLE
Managed aligned memory

### DIFF
--- a/torch_tvm/memory_utils.cpp
+++ b/torch_tvm/memory_utils.cpp
@@ -1,0 +1,58 @@
+#include <tvm/runtime/device_api.h>
+
+#include "memory_utils.h"
+
+namespace torch_tvm {
+namespace utils {
+
+bool isAligned(void* data_ptr, std::uintptr_t alignment_in_bytes) {
+  auto mask = alignment_in_bytes - 1;
+  TORCH_CHECK((alignment_in_bytes & mask) == 0);
+  return (reinterpret_cast<std::uintptr_t>(data_ptr) & mask) == 0;
+}
+
+DLManagedTensor* allocAndCopyData(const at::Tensor& tensor) {
+
+  DLManagedTensor* dl_managed_tensor = new DLManagedTensor();
+  auto contig_tensor = tensor;
+  if (!tensor.is_contiguous()) {
+    auto contig_tensor = tensor.contiguous();
+  }
+  // managed_tensor_deleter is supplied to unique_ptr as a deleter
+  // of this managed memory. Thus setting deleter to nullptr;
+  dl_managed_tensor->deleter = nullptr;
+  dl_managed_tensor->manager_ctx = dl_managed_tensor;
+  auto& dl_tensor = dl_managed_tensor->dl_tensor;
+
+  auto num_dims = contig_tensor.dim();
+  dl_tensor.ndim = num_dims;
+  dl_tensor.dtype = at::getDLDataType(contig_tensor);
+  int64_t device_id = 0;
+  dl_tensor.ctx = getDLContext(contig_tensor, device_id);
+  dl_tensor.shape = dl_tensor.strides = nullptr;
+  dl_tensor.data = nullptr;
+  dl_tensor.shape = new int64_t[num_dims];
+  dl_tensor.strides = new int64_t[num_dims];
+  TORCH_CHECK(dl_tensor.shape != nullptr && dl_tensor.strides != nullptr,
+      "Memory allocation failed for DLTensor shape and strides"
+      "by ManagedTensors.");
+
+  auto tensor_sizes = contig_tensor.sizes();
+  auto tensor_strides = contig_tensor.strides();
+  for (int64_t i = 0; i < num_dims; ++i) {
+    dl_tensor.shape[i] = tensor_sizes[i];
+    dl_tensor.strides[i] = tensor_strides[i];
+  }
+  dl_tensor.data = aligned_alloc(tvm::runtime::kAllocAlignment,
+      contig_tensor.nbytes());
+  TORCH_CHECK(dl_tensor.data != nullptr,
+      "Memory allocation failed for DLTensor data by ManagedTensors.");
+
+  std::memcpy (dl_tensor.data, contig_tensor.data_ptr(), contig_tensor.nbytes());
+  dl_tensor.byte_offset = 0;
+
+  return dl_managed_tensor;
+}
+
+} // utils
+} // torch_tvm

--- a/torch_tvm/memory_utils.h
+++ b/torch_tvm/memory_utils.h
@@ -1,0 +1,37 @@
+#pragma  once
+
+#include <ATen/DLConvertor.h>
+#include <ATen/Tensor.h>
+#include <torch/csrc/jit/ir.h>
+
+#include <dlpack/dlpack.h>
+
+#include <memory>
+
+namespace torch_tvm {
+namespace utils {
+
+struct DLManagedTensorDeleter {
+  void operator()(DLManagedTensor* manager_ctx) {
+    if (manager_ctx == nullptr)
+      return;
+    auto dl_tensor = manager_ctx->dl_tensor;
+    if (dl_tensor.data) {
+      TORCH_CHECK((dl_tensor.shape && dl_tensor.strides), "If DLTensor's data"
+          " pointer is valid then shape and strides must be as well.")
+      delete dl_tensor.data;
+      delete dl_tensor.shape;
+      delete dl_tensor.strides;
+    }
+    delete manager_ctx;
+  }
+};
+
+bool isAligned(void* data_ptr, std::uintptr_t alignment_in_bytes);
+
+DLManagedTensor* allocAndCopyData(const at::Tensor& tensor);
+using DLManagedTensorPtr = std::unique_ptr<DLManagedTensor,
+      DLManagedTensorDeleter>;
+
+} // utils
+} // torch_tvm

--- a/torch_tvm/operators.h
+++ b/torch_tvm/operators.h
@@ -3,6 +3,12 @@
 #include <tvm/relay/expr.h>
 #include <tvm/relay/op.h>
 
+#define PARAM_INDICES_convolution {1, 2}
+#define PARAM_INDICES_layer_norm {2, 3}
+#define PARAM_INDICES_linear {1, 2}
+
+#define PARAM_INDICES(op_name) PARAM_INDICES_##op_name
+
 bool isSupported(torch::jit::Node* node);
 tvm::relay::Expr getOperator(
     torch::jit::Node* node,
@@ -11,17 +17,21 @@ tvm::relay::Expr getOperator(
 bool relayIsNone(tvm::relay::Expr e);
 uint64_t getNoneSentinel();
 
+const std::vector<int32_t>& getParamIndices(torch::jit::Node* node);
+
 using TVMOpFunctor = std::function<tvm::relay::Expr(
     torch::jit::Node* node,
     tvm::Array<tvm::relay::Expr> inputs)>;
 using TVMScheduleFunctor = std::function<const tvm::runtime::PackedFunc*()>;
 
 struct TVMOpMap {
-  TVMOpMap(torch::jit::Symbol sym_, TVMOpFunctor fn_, std::string name_ = "")
-      : sym(sym_), fn(fn_), name(name_) {}
+  TVMOpMap(torch::jit::Symbol sym_, TVMOpFunctor fn_, std::string name_ = ""
+      ,std::vector<int32_t> param_indices_={})
+      : sym(sym_), fn(fn_), name(name_), param_indices(param_indices_){}
 
   torch::jit::Symbol sym;
   TVMOpFunctor fn;
+  std::vector<int32_t> param_indices;
   std::string name;
 };
 


### PR DESCRIPTION
    1. Managed DLTensor when input PT Tensor is unaligned.
       It maintains allocation and eallocation DLTensors corresponding
       PT Values and maintains a map of it.
    2. Managed param tensor just wraps that and assumes that parameters
       are immutable. Thus if a param tensor is created using
       ManagedParamTensors then it will return a cached copy of the tensor
       corresponding to the Value* if one exists. If not allocation and copy
       from corresponding PT tensor is performed. This happens only if
       input PT tensor is unaligned.
    3. Adds a way to annotate ops to specify which of their inputs are
       parameters that are expected to be immutable.

Need to add a few test to validate no memory leaks.