### PR TITLE
Added support for dropout in TVM which essentially is just skipping it.

### DIFF
--- a/torch_tvm/operators.cpp
+++ b/torch_tvm/operators.cpp
@@ -539,6 +539,15 @@ RegisterTVMOperator reg({
          { inputs[0] },
          tvm::Attrs(softmax_attrs));
      }},
+     {Symbol::fromQualString("aten::dropout"),
+     [](Node* node, tvm::Array<tvm::relay::Expr> inputs) {
+       TORCH_CHECK(inputs.size() == 3, "Expected number of inputs 3, got ",
+           inputs.size());
+       auto train = relayToConstant<bool>(inputs[2]);
+       TORCH_CHECK(!train, "Only inference mode dropout is supported"
+           " in torch tvm");
+       return inputs[0];
+     }},
 });
 
 bool isSupported(Node* node) {


### PR DESCRIPTION
Summary:
Ensure that the training mode is false in dropout node. 
If so just returns the input expr instead of creating a new one.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: