### PR TITLE
Convert PT Int to 64 bit

### DIFF
--- a/torch_tvm/compiler.cpp
+++ b/torch_tvm/compiler.cpp
@@ -98,8 +98,6 @@ tvm::relay::Expr TVMCompiler::convertToRelay(
   if (val.isInt()) {
     auto x = tvm::runtime::NDArray::Empty({}, tvm::Int(64), ctx);
     auto l = val.toInt();
-    TORCH_CHECK(l <= std::numeric_limits<int64_t>::max());
-    TORCH_CHECK(l >= std::numeric_limits<int64_t>::lowest());
     reinterpret_cast<int64_t*>(x->data)[0] = l;
     auto v = tvm::relay::ConstantNode::make(x);
     return v;
@@ -124,8 +122,6 @@ tvm::relay::Expr TVMCompiler::convertToRelay(
     tvm::Array<tvm::relay::Expr> tuple_elems;
     for (const auto& elem : val.toIntList()) {
       auto x = tvm::runtime::NDArray::Empty({}, tvm::Int(64), ctx);
-      TORCH_CHECK(elem <= std::numeric_limits<int64_t>::max());
-      TORCH_CHECK(elem >= std::numeric_limits<int64_t>::lowest());
       reinterpret_cast<int64_t*>(x->data)[0] = elem;
       auto v = tvm::relay::ConstantNode::make(x);
       tuple_elems.push_back(v);

--- a/torch_tvm/compiler.cpp
+++ b/torch_tvm/compiler.cpp
@@ -96,12 +96,11 @@ tvm::relay::Expr TVMCompiler::convertToRelay(
   }
   // All Ints are converted to int32, which may overflow
   if (val.isInt()) {
-    auto x = tvm::runtime::NDArray::Empty(
-        {}, tvm::runtime::String2TVMType("int32"), ctx);
+    auto x = tvm::runtime::NDArray::Empty({}, tvm::Int(64), ctx);
     auto l = val.toInt();
-    TORCH_CHECK(l <= std::numeric_limits<int32_t>::max());
-    TORCH_CHECK(l >= std::numeric_limits<int32_t>::lowest());
-    reinterpret_cast<int32_t*>(x->data)[0] = l;
+    TORCH_CHECK(l <= std::numeric_limits<int64_t>::max());
+    TORCH_CHECK(l >= std::numeric_limits<int64_t>::lowest());
+    reinterpret_cast<int64_t*>(x->data)[0] = l;
     auto v = tvm::relay::ConstantNode::make(x);
     return v;
   }
@@ -124,11 +123,10 @@ tvm::relay::Expr TVMCompiler::convertToRelay(
   if (val.isIntList()) {
     tvm::Array<tvm::relay::Expr> tuple_elems;
     for (const auto& elem : val.toIntList()) {
-      auto x = tvm::runtime::NDArray::Empty(
-          {}, tvm::runtime::String2TVMType("int32"), ctx);
-      TORCH_CHECK(elem <= std::numeric_limits<int32_t>::max());
-      TORCH_CHECK(elem >= std::numeric_limits<int32_t>::lowest());
-      reinterpret_cast<int32_t*>(x->data)[0] = elem;
+      auto x = tvm::runtime::NDArray::Empty({}, tvm::Int(64), ctx);
+      TORCH_CHECK(elem <= std::numeric_limits<int64_t>::max());
+      TORCH_CHECK(elem >= std::numeric_limits<int64_t>::lowest());
+      reinterpret_cast<int64_t*>(x->data)[0] = elem;
       auto v = tvm::relay::ConstantNode::make(x);
       tuple_elems.push_back(v);
     }


### PR DESCRIPTION
Summary:
PT ints are 64 bit integers. Without this type mismatch is causing
asserts on TVM side. This PR fixes that.

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: