### PR TITLE
Remove dropout

### DIFF
--- a/torch_tvm/operators.cpp
+++ b/torch_tvm/operators.cpp
@@ -619,15 +619,6 @@ RegisterTVMOperator reg({
          { inputs[0] },
          tvm::Attrs(softmax_attrs));
      }},
-     {Symbol::fromQualString("aten::dropout"),
-     [](Node* node, tvm::Array<tvm::relay::Expr> inputs) {
-       TORCH_CHECK(inputs.size() == 3, "Expected number of inputs 3, got ",
-           inputs.size());
-       auto train = relayToConstant<bool>(inputs[2]);
-       TORCH_CHECK(!train, "Only inference mode dropout is supported"
-           " in torch tvm");
-       return inputs[0];
-     }},
 });
 
 bool isSupported(Node* node) {

--- a/torch_tvm/register.cpp
+++ b/torch_tvm/register.cpp
@@ -9,6 +9,7 @@
 #include "fuse_linear.h"
 #include "fuse_concat.h"
 #include "fusion_pass.h"
+#include "remove_dropout.h"
 
 namespace py = pybind11;
 using namespace torch::jit;
@@ -50,6 +51,7 @@ PYBIND11_MODULE(_torch_tvm, m) {
     if (fusion_enabled) {
       FuseLinear(g);
       FuseConcat(g);
+      RemoveDropout(g);
       FuseSupportedOps(g);
     }
   });

--- a/torch_tvm/remove_dropout.cpp
+++ b/torch_tvm/remove_dropout.cpp
@@ -1,0 +1,35 @@
+#include "remove_dropout.h"
+
+using namespace torch::jit;
+
+bool isDropoutRemovable(const Node* node) {
+  const auto inputs = node->inputs();
+  TORCH_INTERNAL_ASSERT(inputs.size() == 3);
+  const Value* training_input = inputs[2];
+  auto optional_ivalue = toIValue(training_input);
+  TORCH_INTERNAL_ASSERT(optional_ivalue.has_value());
+  const IValue& val = optional_ivalue.value();
+  TORCH_INTERNAL_ASSERT(val.isBool());
+  const bool is_training = val.toBool();
+  return !is_training;
+}
+
+void RemoveDropout(std::shared_ptr<Graph>& graph) {
+  auto block = graph->block();
+  std::vector<Node *> deleted_nodes;
+
+  for (auto it = block->nodes().rbegin(); it != block->nodes().rend(); it++) {
+    Node* node = *it;
+    if (node->kind() == aten::dropout && isDropoutRemovable(*it)) {
+      // Input tensor of dropout.
+      Value* input_value = node->inputs()[0];
+      // Output tensor.
+      Value* output_value = node->outputs()[0];
+      output_value->replaceAllUsesWith(input_value);
+      deleted_nodes.push_back(node);
+    }
+  }
+  for(auto del_node : deleted_nodes) {
+    del_node->destroy();
+  }
+}

--- a/torch_tvm/remove_dropout.h
+++ b/torch_tvm/remove_dropout.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <torch/csrc/jit/ir.h>
+
+TORCH_API void RemoveDropout(std::shared_ptr<torch::jit::Graph>& graph);


### PR DESCRIPTION
Alteration pass to remove dropout nodes when training is false.
Existing mapping of dropout node is faulty and has correctness issues. Since removing dropout node when training=false can benefit PT as well, just decided to implement that instead.
Summary:

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags: