### PR TITLE
Quantized linear opt

### DIFF
--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -340,10 +340,10 @@ class TestOperators(TVMTest):
             torch.fbgemm_linear_quantize_weight(weight.clone().float())
         packed_weight = torch.fbgemm_pack_quantized_matrix(q_weight.clone())
 
-        def fbgemm_quantized_linear(input, weight, bias):
+        def fbgemm_quantized_linear(input, weight, bias, col_offsets):
             return torch.fbgemm_linear_int8_weight_fp32_activation(
-                input.float(), q_weight, packed_weight, col_offsets, scale, zero_point, bias.float())
-        ref_out, tvm_out = self.runBoth(fbgemm_quantized_linear, input, weight, bias)
+                input.float(), weight, packed_weight, col_offsets, scale, zero_point, bias.float())
+        ref_out, tvm_out = self.runBoth(fbgemm_quantized_linear, input, weight, bias, col_offsets)
         # relax the constraint to avoid flaky test
         assert torch.allclose(ref_out, tvm_out, rtol=0.5, atol=0.5)
 

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -328,8 +328,10 @@ class TestOperators(TVMTest):
         assert torch.allclose(ref_out_no_bias, tvm_out_no_bias, rtol=0.01, atol=0.01)
 
 
+    # Have to make min_dim large since we may compare non tensorized imlementation
+    # against fbgemm and that requires K dim to be large enough.
     @TVMTest.given(
-        shape=TVMTest.rand_shape(rank=2, min_dim=10),
+        shape=TVMTest.rand_shape(rank=2, min_dim=32, max_dim=64),
         out_features=TVMTest.rand_int(15, 64),
     )
     def test_quantized_linear(self, shape, out_features):
@@ -343,9 +345,9 @@ class TestOperators(TVMTest):
         shape[1] = shape[1] * 4
         if out_features > 16:
             out_features = out_features * 16
-        input = torch.rand(shape)
-        weight = torch.rand(out_features, shape[1])
-        bias = torch.rand(out_features)
+        input = torch.normal(torch.rand(shape))
+        weight = torch.normal(torch.rand(out_features, shape[1]))
+        bias = torch.normal(torch.rand(out_features))
         q_weight, col_offsets, scale, zero_point = \
             torch.fbgemm_linear_quantize_weight(weight.clone().float())
         packed_weight = torch.fbgemm_pack_quantized_matrix(q_weight.clone())

--- a/test/test_operators.py
+++ b/test/test_operators.py
@@ -1,5 +1,5 @@
 import unittest
-from util import TVMTest
+from test.util import TVMTest
 from torch.testing import FileCheck
 
 import torch

--- a/torch_tvm/__init__.py
+++ b/torch_tvm/__init__.py
@@ -9,7 +9,7 @@ from tvm import relay # This registers all the schedules
 from ._torch_tvm import *
 from ._torch_tvm import _push_relay_expr
 from tvm._ffi.function import _init_api # This lets us use PackedFunc with torch_tvm
-from torch_tvm.custom_tvm_ops.relay import custom_fp32_dense
+from torch_tvm import custom_tvm_ops
 _init_api("torch_tvm")
 
 def to_relay(pt_func, inputs):

--- a/torch_tvm/custom_tvm_ops/__init__.py
+++ b/torch_tvm/custom_tvm_ops/__init__.py
@@ -1,0 +1,2 @@
+from .relay import custom_fp32_dense
+from .relay import quantized_linear_int8

--- a/torch_tvm/custom_tvm_ops/cpp/relay/quantize.h
+++ b/torch_tvm/custom_tvm_ops/cpp/relay/quantize.h
@@ -23,6 +23,14 @@ bool DataInt8QuantizationRel(
     const Attrs& attrs,
     const TypeReporter& reporter);
 
+Expr MakeDataInt8RowOffset(Expr data);
+
+bool DataInt8RowOffsetRel(
+    const Array<Type>& types,
+    int num_inputs,
+    const Attrs& attrs,
+    const TypeReporter& reporter);
+
 Expr MakeFindMinMax(Expr data);
 
 bool FindMinMaxRel(

--- a/torch_tvm/custom_tvm_ops/cpp/relay/quantize.h
+++ b/torch_tvm/custom_tvm_ops/cpp/relay/quantize.h
@@ -39,7 +39,8 @@ Expr MakeDataMMDequantize(
     Expr data_scale,
     Expr data_zero_point,
     const double w_scale,
-    const int w_zp);
+    const int w_zp,
+    const int N);
 
 bool DataMMDequantizeRel(
     const Array<Type>& types,

--- a/torch_tvm/custom_tvm_ops/cpp/relay/quantize_attrs.h
+++ b/torch_tvm/custom_tvm_ops/cpp/relay/quantize_attrs.h
@@ -20,12 +20,19 @@ struct QuantizeSchemeAttrs : public tvm::AttrsNode<QuantizeSchemeAttrs> {
 struct QuantizedParamsAttrs : public tvm::AttrsNode<QuantizedParamsAttrs> {
   double w_scale;
   int w_zp;
+  /*
+   * This param appears here because, input shape of weight change due to
+   * packing thus need this to convey what is the true output shape.
+   */
+  int N;
 
    TVM_DECLARE_ATTRS(QuantizedParamsAttrs, "relay.attrs.QuantizedParamsAttrs") {
     TVM_ATTR_FIELD(w_scale).set_default(1.0)
       .describe("weight scale.");
     TVM_ATTR_FIELD(w_zp).set_default(0)
       .describe("weight zero point.");
+    TVM_ATTR_FIELD(N).set_default(-1)
+      .describe("N dim of output matrix in MxN.");
   }
 };
 }

--- a/torch_tvm/custom_tvm_ops/cpp/relay/quantize_init.cc
+++ b/torch_tvm/custom_tvm_ops/cpp/relay/quantize_init.cc
@@ -21,6 +21,9 @@ TVM_REGISTER_NODE_TYPE(QuantizeSchemeAttrs);
 TVM_REGISTER_API("relay.op.nn._make.quantize_data_int8_quantize")
   .set_body_typed(MakeDataInt8Quantization);
 
+TVM_REGISTER_API("relay.op.nn._make.quantize_data_int8_row_offset")
+  .set_body_typed(MakeDataInt8RowOffset);
+
 
 RELAY_REGISTER_OP("nn.quantize_data_int8_quantize")
 .describe(R"code(dynamic quantization of activation.
@@ -33,6 +36,16 @@ RELAY_REGISTER_OP("nn.quantize_data_int8_quantize")
   .set_attrs_type_key("relay.attrs.QuantizeSchemeAttrs")
   .set_support_level(10)
   .add_type_rel("DataInt8Quantization", DataInt8QuantizationRel);
+
+
+RELAY_REGISTER_OP("nn.quantize_data_int8_row_offset")
+.describe(R"code(dynamic row offset calculation of quantized data.
+- **data**: (M, N)
+)code" TVM_ADD_FILELINE)
+  .set_num_inputs(1)
+  .add_argument("data", "Tensor", "Quantized input tensor.")
+  .set_support_level(10)
+  .add_type_rel("DataInt8RowOffset", DataInt8RowOffsetRel);
 
 
 TVM_REGISTER_API("relay.op.nn._make.quantize_findminmax")

--- a/torch_tvm/custom_tvm_ops/cpp/topi/contrib/quantize.cc
+++ b/torch_tvm/custom_tvm_ops/cpp/topi/contrib/quantize.cc
@@ -3,6 +3,7 @@
 #include <tvm/runtime/util.h>
 #include <cmath>
 #include <iostream>
+#include <limits>
 
 namespace tvm {
 namespace contrib {
@@ -23,9 +24,9 @@ TVM_REGISTER_GLOBAL("tvm.contrib.find_minmax")
       int num_els = m * n;
       int num_iters = num_els / 16;
       int num_left_overs = num_els % 16;
-      float min_v[16] = {0.f};
-      float max_v[16] = {0.f};
-      for (int i = 0; i < m; i++) {
+      float min_v[16] = {std::numeric_limits<float>::max()};
+      float max_v[16] = {std::numeric_limits<float>::lowest()};
+      for (int i = 0; i < num_iters; i++) {
         for (int j = 0; j < 16; j++) {
             min_v[j] = std::min(data_ptr[i*16 + j], min_v[j]);
             max_v[j] = std::max(data_ptr[i*16 + j], max_v[j]);

--- a/torch_tvm/custom_tvm_ops/cpp/topi/custom_topi_ops.cc
+++ b/torch_tvm/custom_tvm_ops/cpp/topi/custom_topi_ops.cc
@@ -124,28 +124,9 @@ class CustomTOPIOpRegisterer {
         static_cast<int>(OpPatternKind::kOutEWiseFusable),
         10);
     (*reg_ptr)(
-        "nn.quantize_data_int8_quantize",
-        "FTVMCompute",
-        tvm::relay::FTVMCompute(
-            [](const tvm::Attrs& attrs,
-               const tvm::Array<tvm::Tensor>& inputs,
-               const tvm::relay::Type& out_type,
-               const tvm::Target& target) -> tvm::Array<tvm::Tensor> {
-              const auto* param = attrs.as<relay::QuantizeSchemeAttrs>();
-              auto precision = param->precision;
-              auto is_signed = param->is_signed;
-              return topi::data_int8_quantize(inputs[0], inputs[1], inputs[2], is_signed, precision);
-            }),
-        10);
-    (*reg_ptr)(
-        "nn.quantize_data_int8_quantize",
-        "FTVMSchedule",
-        tvm::relay::FTVMSchedule(
-            [](const tvm::Attrs& attrs,
-               const tvm::Array<tvm::Tensor>& outs,
-               const tvm::Target& target) -> tvm::Schedule {
-              return topi::generic::schedule_quantize_data_int8_quantize(outs);
-            }),
+        "nn.quantize_data_int8_row_offset",
+        "TOpPattern",
+        static_cast<int>(OpPatternKind::kOutEWiseFusable),
         10);
     (*reg_ptr)(
         "nn.quantize_data_mm_dequantize",
@@ -182,6 +163,19 @@ TVM_REGISTER_GLOBAL("nn.compute_quantized_mm_dequantize")
       *rv = data_int8_mm_dequantize(
         args[0], args[1], args[2], args[3],
         args[4], args[5], args[6], args[7], args[8]);
+    });
+
+TVM_REGISTER_GLOBAL("nn.compute_data_int8_quantize")
+    .set_body([](TVMArgs args, TVMRetValue* rv) {
+      CHECK(args.size() == 5);
+      *rv = data_int8_quantize(
+        args[0], args[1], args[2], args[3], args[4]);
+    });
+
+TVM_REGISTER_GLOBAL("nn.compute_data_int8_row_offset")
+    .set_body([](TVMArgs args, TVMRetValue* rv) {
+      CHECK(args.size() == 1);
+      *rv = data_int8_row_offset(args[0]);
     });
 
 } // namespace topi

--- a/torch_tvm/custom_tvm_ops/cpp/topi/custom_topi_ops.cc
+++ b/torch_tvm/custom_tvm_ops/cpp/topi/custom_topi_ops.cc
@@ -152,30 +152,6 @@ class CustomTOPIOpRegisterer {
         "TOpPattern",
         static_cast<int>(OpPatternKind::kOutEWiseFusable),
         10);
-    (*reg_ptr)(
-        "nn.quantize_data_mm_dequantize",
-        "FTVMCompute",
-        tvm::relay::FTVMCompute(
-            [](const tvm::Attrs& attrs,
-               const tvm::Array<tvm::Tensor>& inputs,
-               const tvm::relay::Type& out_type,
-               const tvm::Target& target) -> tvm::Array<tvm::Tensor> {
-              const auto* param = attrs.as<relay::QuantizedParamsAttrs>();
-              return topi::data_int8_mm_dequantize(
-                inputs[0], inputs[1], inputs[2], inputs[3],
-                inputs[4], inputs[5], param->w_scale, param->w_zp);
-            }),
-        10);
-    (*reg_ptr)(
-        "nn.quantize_data_mm_dequantize",
-        "FTVMSchedule",
-        tvm::relay::FTVMSchedule(
-            [](const tvm::Attrs& attrs,
-               const tvm::Array<tvm::Tensor>& outs,
-               const tvm::Target& target) -> tvm::Schedule {
-              return topi::generic::schedule_quantize_data_mm_dequantize(outs);
-            }),
-        10);
   }
 };
 
@@ -198,6 +174,14 @@ TVM_REGISTER_GLOBAL("nn.custom_layer_norm")
           args[3],
           args[4],
           static_cast<double>(args[5]));
+    });
+
+TVM_REGISTER_GLOBAL("nn.compute_quantized_mm_dequantize")
+    .set_body([](TVMArgs args, TVMRetValue* rv) {
+      CHECK(args.size() == 9);
+      *rv = data_int8_mm_dequantize(
+        args[0], args[1], args[2], args[3],
+        args[4], args[5], args[6], args[7], args[8]);
     });
 
 } // namespace topi

--- a/torch_tvm/custom_tvm_ops/cpp/topi/generic/quantize_generic_sched.h
+++ b/torch_tvm/custom_tvm_ops/cpp/topi/generic/quantize_generic_sched.h
@@ -44,6 +44,16 @@ inline Schedule schedule_quantize_data_int8_quantize(
   return s;
 }
 
+inline Schedule schedule_quantize_data_int8_row_offset(
+    const Array<Tensor>& outs) {
+  Array<Operation> out_ops;
+  for (auto out : outs) {
+    out_ops.push_back(out->op);
+  }
+  auto s = create_schedule(out_ops);
+  return s;
+}
+
 inline Schedule schedule_quantize_data_mm_dequantize(
     const Array<Tensor>& outs) {
   Array<Operation> out_ops;

--- a/torch_tvm/custom_tvm_ops/cpp/topi/quantize.cc
+++ b/torch_tvm/custom_tvm_ops/cpp/topi/quantize.cc
@@ -35,17 +35,23 @@ Array<Tensor> data_int8_quantize(
       "tensor",
       "int8_quantize"
       );
-  auto k = tvm::reduce_axis(Range(0, data->shape[1]), "k");
+
+  return {clamp_output};
+}
+
+Array<Tensor> data_int8_row_offset(const Tensor& quantized_data) {
+
+  auto k = tvm::reduce_axis(Range(0, quantized_data->shape[1]), "k");
   auto data_acc = tvm::compute(
-      {data->shape[0]},
+      {quantized_data->shape[0]},
       [&](Var i) {
-          return tvm::sum(tvm::cast(Int(32), clamp_output(i, k)), {k});
+          return tvm::sum(tvm::cast(Int(32), quantized_data(i, k)), {k});
       },
       "tensor",
       "int8_quantize_acc"
       );
 
-  return {clamp_output, data_acc};
+  return {data_acc};
 }
 
 Array<Tensor> data_int8_mm_dequantize(

--- a/torch_tvm/custom_tvm_ops/cpp/topi/quantize.cc
+++ b/torch_tvm/custom_tvm_ops/cpp/topi/quantize.cc
@@ -56,24 +56,26 @@ Array<Tensor> data_int8_mm_dequantize(
     const Tensor& data_scale,
     const Tensor& data_zero_point,
     const double weight_scale,
-    const int weight_zero_point) {
+    const int weight_zero_point,
+    const int32_t N) {
   // assume M, K and N, K on input shape
-  CHECK(weight->shape.size() == 2);
+  CHECK(weight->shape.size() == 4);
   auto k = tvm::reduce_axis(Range(0, data->shape[1]), "k");
   auto scale_mul = make_const(Float(32), weight_scale) * data_scale(0);
+  auto out_shape = {data->shape[0], weight->shape[0] * weight->shape[2]};
 
   auto quantized_mm = tvm::compute(
-        {data->shape[0], weight->shape[0]},
+        out_shape,
         [&](Var i, Var j) {
-          return tvm::sum(tvm::cast(Int(32), data(i, k)) * tvm::cast(Int(32), weight(j, k)), {k});
+          return tvm::sum(tvm::cast(Int(32), data(i, k)) * tvm::cast(Int(32), weight(j / 16, k / 4, j % 16, k % 4)), {k});
         },
         "tensor",
-        "dequantized_mm"
+        "quantized_mm"
       );
   auto zero_point_mul = weight_zero_point*data_zero_point(0)*(data->shape[1]);
 
   auto result = tvm::compute(
-        {data->shape[0], weight->shape[0]},
+        {data->shape[0], Expr(N)},
         [&](Var i, Var j) {
           return scale_mul*(tvm::cast(Float(32), (quantized_mm(i, j)-data_acc(i)*weight_zero_point-
                             weight_acc(j)*data_zero_point(0) + zero_point_mul)));

--- a/torch_tvm/custom_tvm_ops/cpp/topi/quantize.h
+++ b/torch_tvm/custom_tvm_ops/cpp/topi/quantize.h
@@ -22,6 +22,7 @@ Array<Tensor> data_int8_mm_dequantize(
     const Tensor& data_scale,
     const Tensor& data_zero_point,
     const double weight_scale,
-    const int weight_zero_point);
+    const int weight_zero_point,
+    const int N);
 
 } // namespace topi

--- a/torch_tvm/custom_tvm_ops/cpp/topi/quantize.h
+++ b/torch_tvm/custom_tvm_ops/cpp/topi/quantize.h
@@ -14,6 +14,8 @@ Array<Tensor> data_int8_quantize(
     bool is_signed,
     int precision);
 
+Array<Tensor> data_int8_row_offset(const Tensor& quantized_data);
+
 Array<Tensor> data_int8_mm_dequantize(
     const Tensor& data,
     const Tensor& weight,

--- a/torch_tvm/custom_tvm_ops/relay/quantized_linear_int8.py
+++ b/torch_tvm/custom_tvm_ops/relay/quantized_linear_int8.py
@@ -1,0 +1,34 @@
+from __future__ import absolute_import
+
+import topi
+from tvm.relay.op import op as reg
+from tvm.relay.op.op import OpPattern, schedule_injective
+from topi.util import get_const_int
+from tvm import autotvm
+import tvm
+
+from torch_tvm.custom_tvm_ops.topi import quantized_linear_int8
+
+@reg.register_compute("nn.quantize_data_mm_dequantize")
+def compute_quantized_mm_dequantize(attrs, inputs, out_type, target):
+    data = inputs[0]
+    weight = inputs[1]
+    weight_acc = inputs[2]
+    data_acc = inputs[3]
+    data_scale = inputs[4]
+    data_zero_point = inputs[5]
+    weight_scale = attrs.w_scale
+    weight_zero_point = attrs.w_zp
+    N = attrs.N
+    out = quantized_linear_int8.quantized_mm_dequantize(data, weight, \
+            weight_acc, data_acc, data_scale, data_zero_point, weight_scale, \
+            weight_zero_point, N, out_type.dtype)
+    return [out]
+
+
+@reg.register_schedule("nn.quantize_data_mm_dequantize")
+def schedule_quantized_mm_dequantize(attrs, outs, target):
+    with target:
+        return quantized_linear_int8.schedule_quantized_mm_dequantize(outs)
+
+

--- a/torch_tvm/custom_tvm_ops/relay/quantized_linear_int8.py
+++ b/torch_tvm/custom_tvm_ops/relay/quantized_linear_int8.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 import topi
 from tvm.relay.op import op as reg
-from tvm.relay.op.op import OpPattern, schedule_injective
-from topi.util import get_const_int
 from tvm import autotvm
 import tvm
 
@@ -45,7 +43,7 @@ def compute_data_int8_quantize(attrs, inputs, out_type, target):
 
 
 @reg.register_schedule("nn.quantize_data_int8_quantize")
-def schedule_quantized_mm_dequantize(attrs, outs, target):
+def schedule_data_int8_quantize(attrs, outs, target):
     with target:
         return quantized_linear_int8.schedule_data_int8_quantize(outs)
 
@@ -58,6 +56,6 @@ def compute_data_int8_row_offset(attrs, inputs, out_type, target):
 
 
 @reg.register_schedule("nn.quantize_data_int8_row_offset")
-def schedule_quantized_mm_dequantize(attrs, outs, target):
+def schedule_data_int8_row_offset(attrs, outs, target):
     with target:
         return quantized_linear_int8.schedule_data_int8_row_offset(outs)

--- a/torch_tvm/custom_tvm_ops/relay/quantized_linear_int8.py
+++ b/torch_tvm/custom_tvm_ops/relay/quantized_linear_int8.py
@@ -32,3 +32,32 @@ def schedule_quantized_mm_dequantize(attrs, outs, target):
         return quantized_linear_int8.schedule_quantized_mm_dequantize(outs)
 
 
+@reg.register_compute("nn.quantize_data_int8_quantize")
+def compute_data_int8_quantize(attrs, inputs, out_type, target):
+    data = inputs[0]
+    zero_point = inputs[1]
+    scale = inputs[2]
+    precision = attrs.precision
+    is_signed = attrs.is_signed
+    out = quantized_linear_int8.data_int8_quantize(data, zero_point, \
+            scale, is_signed, precision, out_type.dtype)
+    return [out]
+
+
+@reg.register_schedule("nn.quantize_data_int8_quantize")
+def schedule_quantized_mm_dequantize(attrs, outs, target):
+    with target:
+        return quantized_linear_int8.schedule_data_int8_quantize(outs)
+
+
+@reg.register_compute("nn.quantize_data_int8_row_offset")
+def compute_data_int8_row_offset(attrs, inputs, out_type, target):
+    data = inputs[0]
+    out = quantized_linear_int8.data_int8_row_offset(data, out_type.dtype)
+    return [out]
+
+
+@reg.register_schedule("nn.quantize_data_int8_row_offset")
+def schedule_quantized_mm_dequantize(attrs, outs, target):
+    with target:
+        return quantized_linear_int8.schedule_data_int8_row_offset(outs)

--- a/torch_tvm/custom_tvm_ops/topi/quantized_linear_int8.py
+++ b/torch_tvm/custom_tvm_ops/topi/quantized_linear_int8.py
@@ -138,12 +138,12 @@ def _schedule_quantized_mm(cfg, s, QGEMM):
             avx_type = AVXType.AVX512
         if option == "-mcpu=core-avx2":
             avx_type = AVXType.AVX2
-    x, y = s[QGEMM].op.axis
+    y, x = s[QGEMM].op.axis
     k, = s[QGEMM].op.reduce_axis
-    yo, yi = s[QGEMM].split(y, factor=16)
+    xo, xi = s[QGEMM].split(x, factor=16)
     ko, ki = s[QGEMM].split(k, factor=4)
-    s[QGEMM].reorder(yo, ko, x, yi, ki)
-    s[QGEMM].unroll(x)
+    s[QGEMM].reorder(xo, ko, y, xi, ki)
+    s[QGEMM].unroll(y)
     if avx_type == AVXType.AVX512:
         pc = dot_16x1x16_int8_int8_int32()
-        s[QGEMM].tensorize(yi, pc)
+        s[QGEMM].tensorize(xi, pc)

--- a/torch_tvm/custom_tvm_ops/topi/quantized_linear_int8.py
+++ b/torch_tvm/custom_tvm_ops/topi/quantized_linear_int8.py
@@ -1,0 +1,81 @@
+import tvm
+from tvm import autotvm
+from tvm.autotvm.task.space import SplitEntity
+
+from topi.nn.util import get_pad_tuple
+from topi.nn.pad import pad
+from topi.util import simplify, get_const_tuple
+from topi.generic import nn
+from topi import tag
+
+@tvm.target.generic_func
+def quantized_mm_dequantize(data, weight, weight_acc, data_acc, data_scale, \
+        data_zero_point, weight_scale, weight_zero_point, N, out_dtype=None):
+    quantized_mm_dequant_fn = \
+            tvm.get_global_func("nn.compute_quantized_mm_dequantize")
+    return quantized_mm_dequant_fn(data, weight, weight_acc, data_acc, data_scale, \
+            data_zero_point, weight_scale, weight_zero_point, N)[0]
+
+
+# The reason to have to register_topi_compute at all is due to the fact that
+# "workload" attr is annotated only during this decorator. We need "workload"
+# attr for register_topi_schedule which is inturn needed to be able to autotune.
+# "workload" can perhaps be annotated from the c++ counterpart but that is not the
+# prevailing practice. Plus it also seems cleaner to do it here.
+# Although admittedly this all looks like just a hack, but that is due to way
+# autotvm machinary works.
+@autotvm.register_topi_compute(quantized_mm_dequantize, 'cpu', ['direct'])
+def _quantized_mm_dequantize_dummy(cfg, data, weight, weight_acc, data_acc, \
+        data_scale, data_zero_point, weight_scale, weight_zero_point, N, \
+        out_dtype):
+    quantized_mm_dequant_fn = \
+            tvm.get_global_func("nn.compute_quantized_mm_dequantize")
+    return quantized_mm_dequant_fn(data, weight, weight_acc, data_acc, data_scale, \
+            data_zero_point, weight_scale, weight_zero_point, N)[0]
+
+
+@tvm.target.generic_func
+def schedule_quantized_mm_dequantize(outs):
+    return nn._default_schedule(outs, False)
+
+
+@autotvm.register_topi_schedule(schedule_quantized_mm_dequantize, 'cpu', ['direct'])
+def _schedule_quantized_mm_dequantize(cfg, outs):
+    s = tvm.create_schedule([x.op for x in outs])
+    scheduled_ops = []
+
+    def traverse(op):
+        """Traverse operators from computation graph"""
+        # inline all one-to-one-mapping operators except the last stage (output)
+        if tag.is_broadcast(op.tag):
+            if op not in s.outputs:
+                s[op].compute_inline()
+            for tensor in op.input_tensors:
+                if isinstance(tensor.op, tvm.tensor.ComputeOp) and \
+                        tensor.op not in scheduled_ops:
+                    traverse(tensor.op)
+
+        if 'mm_dequantize' in op.tag:
+            output = op.output(0)
+            _schedule_mm_dequantize(cfg, s, output)
+
+        scheduled_ops.append(op)
+
+    traverse(outs[0].op)
+    return s
+
+
+def _schedule_mm_dequantize(cfg, s, C):
+    input_tensors = C.op.input_tensors
+    for input_tensor in input_tensors:
+        if "quantized_mm" in input_tensor.op.tag:
+            _schedule_quantized_mm(cfg, s, input_tensor)
+
+
+def _schedule_quantized_mm(cfg, s, QGEMM):
+    x, y = s[QGEMM].op.axis
+    k, = s[QGEMM].op.reduce_axis
+    yo, yi = s[QGEMM].split(y, factor=16)
+    ko, ki = s[QGEMM].split(k, factor=4)
+    s[QGEMM].reorder(yo, ko, x, yi, ki)
+    s[QGEMM].unroll(x)

--- a/torch_tvm/custom_tvm_ops/topi/quantized_linear_int8.py
+++ b/torch_tvm/custom_tvm_ops/topi/quantized_linear_int8.py
@@ -141,7 +141,7 @@ def _schedule_quantized_mm(cfg, s, QGEMM):
     y, x = s[QGEMM].op.axis
     k, = s[QGEMM].op.reduce_axis
     xo, xi = s[QGEMM].split(x, factor=16)
-    x_dim_size = get_const_int(QGEMM.shape[0])
+    x_dim_size = get_const_int(QGEMM.shape[1])
     if x_dim_size >= 16:
         ko, ki = s[QGEMM].split(k, factor=4)
         s[QGEMM].reorder(xo, ko, y, xi, ki)

--- a/torch_tvm/custom_tvm_ops/topi/quantized_linear_int8.py
+++ b/torch_tvm/custom_tvm_ops/topi/quantized_linear_int8.py
@@ -1,10 +1,7 @@
 import tvm
 from tvm import autotvm
-from tvm.autotvm.task.space import SplitEntity
 
-from topi.nn.util import get_pad_tuple
-from topi.nn.pad import pad
-from topi.util import simplify, get_const_tuple, get_const_int
+from topi.util import get_const_int
 from topi.generic import nn
 from topi import tag
 from topi.x86.tensor_intrin import dot_16x1x16_int8_int8_int32

--- a/torch_tvm/operators.cpp
+++ b/torch_tvm/operators.cpp
@@ -164,7 +164,6 @@ tvm::relay::Expr lowerFbgemmLinearInt8Acc32FP32(tvm::Array<tvm::relay::Expr> inp
   const auto weight_type = getExprType(inputs[1]);
   auto weight_shape = weight_type.shape;
   int N = (weight_shape[0].as<tvm::IntImm>())->value;
-  int K = (weight_shape[0].as<tvm::IntImm>())->value;
   tvm::relay::Expr packed_weight = insertInt8WeightTransform(inputs[1], N);
 
   tvm::Array<tvm::relay::Expr> deq_inputs = {q_data, packed_weight, inputs[3],

--- a/torch_tvm/operators.h
+++ b/torch_tvm/operators.h
@@ -6,6 +6,7 @@
 #define PARAM_INDICES_convolution {1, 2}
 #define PARAM_INDICES_layer_norm {2, 3}
 #define PARAM_INDICES_linear {1, 2}
+#define PARAM_INDICES_quantized_linear {1, 3, 6}
 
 #define PARAM_INDICES(op_name) PARAM_INDICES_##op_name
 

--- a/torch_tvm/register.cpp
+++ b/torch_tvm/register.cpp
@@ -34,7 +34,7 @@ PYBIND11_MODULE(_torch_tvm, m) {
   options.setAliasAnalysis(AliasAnalysisKind::PURE_FUNCTION);
   RegisterOperators op({Operator(
       getTVMSymbol(),
-      [](const Node* node) {
+      [](const Node* node) -> Operation {
         auto cc = std::make_shared<TVMCompiler>(
             node, opt_level, strict, device_type, device, host);
         return [cc](Stack& stack) {


### PR DESCRIPTION
Tensorize quantized linear.
Fixed a bug in the compute.
Depends on this PR.
https://github.com/facebookexperimental/tvm/pull/7

Specifically this PR does:
- Adds tensorization of compute (depends on the PR mentioned above) for AVX512.
- Reshape of input/output to handle input with > 2 dims.
- Weight reshape that is dependent on 1st dim of weight. That is if weight.shape[0] > 16 we expect shape size to be multiple of 16. Then we pack weight has NK16n4k. If weight.shape[0] < 16 we pack if as NK"weight.shape[0]n4k.
- Bug fixes:
  - In the quantized gemm calculation
```
result = lhs_scale * rhs_scale * Sum_over_i(
        (lhs_quantized_value[i] - lhs_zero_point) *
        (rhs_quantized_value[i] - rhs_zero_point)
    )
```
if you expland you get the last term as
`lhs_zero_point*rhs_zero_point*k`. 
However in fbgemm they do not have this addition. It is not clear yet why or something else is missed. We will followup on this. So this is one bug that is fixed.
- The second bug is more subtle. In input data quantization fbgemm uses rounding whereas we did casting. Casting by default does truncation. So whenever our quantized value is different it is always smaller by 1. When k dim is larger these get accumulated and with scale applied difference gets even larger. The solution was to use `tvm::round`, however this costs us 10% in perf. Debug is under way.

Benchmark comparision is against fbgemm implementation.
Without the rounding we are 10% faster with rounding we are on par. Need to figure out why are we losing perf due to rounding.