### PR TITLE
Switch to nearbyint instead of using round, which costs performance.

### DIFF
--- a/torch_tvm/custom_tvm_ops/cpp/topi/quantize.cc
+++ b/torch_tvm/custom_tvm_ops/cpp/topi/quantize.cc
@@ -26,7 +26,7 @@ Array<Tensor> data_int8_quantize(
   auto clamp_output = tvm::compute(
       data->shape,
       [&](Var i, Var j) {
-         return tvm::cast(target_type, tvm::round(
+         return tvm::cast(target_type, tvm::nearbyint(
             tvm::min(
                tvm::max(tvm::cast(Float(32), zero_point(0)) + data(i, j)*inverse_scale, q_min),
                q_max


### PR DESCRIPTION
Performance loss comes from the fact that llvm does a function call to 'roundf' whereas replacing that with nearbyint just replaces the call with a couple of scale and round instructions.